### PR TITLE
Fix incorrect open count check in release function

### DIFF
--- a/main.c
+++ b/main.c
@@ -428,7 +428,7 @@ static int kxo_open(struct inode *inode, struct file *filp)
 static int kxo_release(struct inode *inode, struct file *filp)
 {
     pr_debug("kxo: %s\n", __func__);
-    if (atomic_dec_and_test(&open_cnt) == 0) {
+    if (atomic_dec_and_test(&open_cnt)) {
         del_timer_sync(&timer);
         flush_workqueue(kxo_workqueue);
         fast_buf_clear();


### PR DESCRIPTION
It is the same idea as [this pull request](https://github.com/sysprog21/simrupt/pull/4#issue-2949758936) of `simrupt`.

After using `insmod` to insert the module, we use the following command to interact with the kernel module in user space:
```
sudo ./xo-user
```
Then, we kill it with Ctrl+C and use `sudo dmesg --follow` to observe the info message, we find that it will consistently produce new boards although no one is interacting with it.
```
[271863.231323] kxo: [CPU#15] enter timer_handler
[271863.231326] kxo: [CPU#15] doing AI game
[271863.231327] kxo: [CPU#15] scheduling tasklet
[271863.231328] kxo: [CPU#15] timer_handler in_irq: 1 usec
[271863.232325] kxo: [CPU#15] game_tasklet_func in_softirq: 0 usec
[271863.335323] kxo: [CPU#15] enter timer_handler
[271863.335327] kxo: [CPU#15] doing AI game
[271863.335328] kxo: [CPU#15] scheduling tasklet
[271863.335329] kxo: [CPU#15] timer_handler in_irq: 1 usec
[271863.336326] kxo: [CPU#15] game_tasklet_func in_softirq: 0 usec
[271863.632290] kxo: [CPU#15] doing ai_one_work_func for 1000720 usec
```

It is because it will stop producing new boards only when `atomic_dec_and_test(&open_cnt)` returns zero in `kxo_release`. 
```cpp
static int kxo_release(struct inode *inode, struct file *filp)
{
    pr_debug("kxo: %s\n", __func__);
    if (atomic_dec_and_test(&open_cnt) == 0) {
        del_timer_sync(&timer);
        flush_workqueue(kxo_workqueue);
        fast_buf_clear();
    }
    pr_info("release, current cnt: %d\n", atomic_read(&open_cnt));

    return 0;
}
```
Reading the comment of `atomic_dec_and_test`，we will find that it will return true if the resulting value of the variable is zero.
```cpp
/**
 * atomic_dec_and_test() - atomic decrement and test if zero with full ordering
 ...
 * Return: @true if the resulting value of @v is zero, @false otherwise.
 */
```
Therefore, if we want it to stop producing new boards when the `open_cnt` becomes zero, we should do the following change.
```diff
- if (atomic_dec_and_test(&open_cnt) == 0) {
+ if (atomic_dec_and_test(&open_cnt)) {
```
As the result, it works normally.
