### PR TITLE
Include <linux/vmalloc.h> explicitly on x86

### DIFF
--- a/main.c
+++ b/main.c
@@ -9,6 +9,9 @@
 #include <linux/sysfs.h>
 #include <linux/version.h>
 #include <linux/workqueue.h>
+#if defined(CONFIG_X86)
+#include <linux/vmalloc.h>
+#endif
 
 #include "game.h"
 #include "mcts.h"

--- a/scripts/aspell-pws
+++ b/scripts/aspell-pws
@@ -177,3 +177,4 @@ kfifo
 PTR
 ttt
 tictactoe
+vmalloc


### PR DESCRIPTION
This pull request is based on the discussion in the pull request [sysprog21/simrupt#6](https://github.com/sysprog21/simrupt/pull/6) and is solving the issue [sysprog21/kxo#1](https://github.com/sysprog21/kxo/issues/1).


According to the commit [1f059dfdf5d1](https://github.com/torvalds/linux/commit/1f059dfdf5d1) ("mm/vmalloc: Add empty <asm/vmalloc.h> headers and use them from <linux/vmalloc.h>"), `<linux/vmalloc.h>` should be explicitly included in x86 architectures after the kernel version `v5.6-rc1`.

In my environment `6.11.0-19-generic`，without this inclusion, it will show the following error message during building:
```
make -C /lib/modules/6.11.0-19-generic/build M=/home/rota1001/linux2025/kxo modules
make[1]: Entering directory '/usr/src/linux-headers-6.11.0-19-generic'
  CC [M]  /home/rota1001/linux2025/kxo/main.o
/home/rota1001/linux2025/kxo/main.c: In function ‘kxo_init’:
/home/rota1001/linux2025/kxo/main.c:494:20: error: implicit declaration of function ‘vmalloc’; did you mean ‘kmalloc’? [-Werror=implicit-function-declaration]
  494 |     fast_buf.buf = vmalloc(PAGE_SIZE);
      |                    ^~~~~~~
      |                    kmalloc
/home/rota1001/linux2025/kxo/main.c:494:18: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  494 |     fast_buf.buf = vmalloc(PAGE_SIZE);
      |                  ^
/home/rota1001/linux2025/kxo/main.c:505:9: error: implicit declaration of function ‘vfree’; did you mean ‘kvfree’? [-Werror=implicit-function-declaration]
  505 |         vfree(fast_buf.buf);
      |         ^~~~~
      |         kvfree
```

And after the explicitly inclusion, it works normally.