### PR TITLE
Always include vmalloc.h on all architectures

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,10 +8,8 @@
 #include <linux/slab.h>
 #include <linux/sysfs.h>
 #include <linux/version.h>
-#include <linux/workqueue.h>
-#if defined(CONFIG_X86)
 #include <linux/vmalloc.h>
-#endif
+#include <linux/workqueue.h>
 
 #include "game.h"
 #include "mcts.h"


### PR DESCRIPTION
Commit 5d29490 ("Only include vmalloc.h on x86", #5 ) limited the inclusion of `<linux/vmalloc.h>` to x86 architectures under the assumption that only x86 required it explicitly.

However, `<linux/vmalloc.h>` is not architecture-specific, and other architectures may currently include it indirectly. To ensure consistency and future compatibility, include `<linux/vmalloc.h>` unconditionally to prevent build failures if indirect includes change in future kernel versions.