### PR TITLE
Add instructions for enabling Control+Q capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ This utility offers the following functionality:
   - `Ctrl + P`: Toggle pause/resume of the game board display
   - `Ctrl + Q`: Terminate all tic-tac-toe games running in kernel space
 
+In terminal environments that use flow control (particularly bash), you must enable the Ctrl+Q shortcut. Run the following command before starting xo-user:
+```
+$ stty start '^-' stop '^-'
+```
+
 Simply run the command below after the kernel module is loaded:
 ```
 $ sudo ./xo-user


### PR DESCRIPTION
Update the README with guidance to disable default terminal flow control that interferes with the Control+Q shortcut. This ensures the shortcut is properly received by the application.