### PR TITLE
Enable Control+Q capture by setting input mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ This utility offers the following functionality:
   - `Ctrl + P`: Toggle pause/resume of the game board display
   - `Ctrl + Q`: Terminate all tic-tac-toe games running in kernel space
 
-In terminal environments that use flow control (particularly bash), you must enable the Ctrl+Q shortcut. Run the following command before starting xo-user:
-```
-$ stty start '^-' stop '^-'
-```
-
 Simply run the command below after the kernel module is loaded:
 ```
 $ sudo ./xo-user

--- a/xo-user.c
+++ b/xo-user.c
@@ -46,6 +46,7 @@ static void raw_mode_enable(void)
     tcgetattr(STDIN_FILENO, &orig_termios);
     atexit(raw_mode_disable);
     struct termios raw = orig_termios;
+    raw.c_iflag &= ~IXON;
     raw.c_lflag &= ~(ECHO | ICANON);
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
 }


### PR DESCRIPTION
Pull request [#9](https://github.com/sysprog21/kxo/pull/9) said that the default flow control of some terminals will interfere with the Control+Q shortcut, so it asked user to use command to disable this. However, this can be done by setting the flag of input mode.

According to the [IEEE Std 1003.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/termios.h.html), we can set the input mode flags in the `c_iflag` field, and `IXON` is the flag to enable start/stop output control (, which is Control+Q and Control+S in bash). Therefore, we can clear the `IXON` flag in the `c_flag` field to enable Control+Q capture.

This has been tested on both bash and zsh, and they successfully show "Stopping the kernel space tic-tac-toe game...".