### PR TITLE
Fix incorrect comments

### DIFF
--- a/game.c
+++ b/game.c
@@ -4,8 +4,8 @@
 
 
 const line_t lines[4] = {
-    {1, 0, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE},             // ROW
-    {0, 1, 0, 0, BOARD_SIZE, BOARD_SIZE - GOAL + 1},             // COL
+    {1, 0, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE},             // COL
+    {0, 1, 0, 0, BOARD_SIZE, BOARD_SIZE - GOAL + 1},             // ROW
     {1, 1, 0, 0, BOARD_SIZE - GOAL + 1, BOARD_SIZE - GOAL + 1},  // PRIMARY
     {1, -1, 0, GOAL - 1, BOARD_SIZE - GOAL + 1, BOARD_SIZE},     // SECONDARY
 };


### PR DESCRIPTION
Correct ROW and COL labels in comments to match standard definitions—column as vertical and row as horizontal. This change improves code clarity and prevents potential confusion when interpreting line direction logic.