### PR TITLE
Fix output garbling and allow clean restart after game exit

### DIFF
--- a/main.c
+++ b/main.c
@@ -435,6 +435,7 @@ static int kxo_release(struct inode *inode, struct file *filp)
         fast_buf_clear();
     }
     pr_info("release, current cnt: %d\n", atomic_read(&open_cnt));
+    attr_obj.end = 48;
 
     return 0;
 }


### PR DESCRIPTION
This pull request includes two key improvements:

1. **Fix output garbling issue**
   - Ensures the display buffer is null-terminated by adding:
     `display_buf[DRAWBUFFER_SIZE - 1] = '\0';`
   - This prevents garbled output when printing the buffer.

2. **Enable clean re-execution of the user program**
   - Previously, after quitting the game via Ctrl+Q, an internal flag remained set,
     preventing subsequent game runs unless the module was reloaded.
   - This patch resets the termination flag when the device is closed.
