### PR TITLE
Enable clean re-execution of the user program

### DIFF
--- a/main.c
+++ b/main.c
@@ -435,6 +435,7 @@ static int kxo_release(struct inode *inode, struct file *filp)
         fast_buf_clear();
     }
     pr_info("release, current cnt: %d\n", atomic_read(&open_cnt));
+    attr_obj.end = 48;
 
     return 0;
 }


### PR DESCRIPTION
Previously, after quitting the game via Ctrl+Q, an internal flag remained set, preventing subsequent game runs unless the module was reloaded.
This patch resets the termination flag when the device is closed.