### PR TITLE
Drop .owner for kernel >= 6.4

### DIFF
--- a/main.c
+++ b/main.c
@@ -440,11 +440,13 @@ static int kxo_release(struct inode *inode, struct file *filp)
 }
 
 static const struct file_operations kxo_fops = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+    .owner = THIS_MODULE,
+#endif
     .read = kxo_read,
     .llseek = no_llseek,
     .open = kxo_open,
     .release = kxo_release,
-    .owner = THIS_MODULE,
 };
 
 static int __init kxo_init(void)


### PR DESCRIPTION
Kernel 6.4+ sets .owner automatically. Remove manual assignment to avoid build issues and keep compatibility with older versions.

Reference : sysprog21/simrupt#12