### PR TITLE
Fix missing newline in sysfs file kxo_state

### DIFF
--- a/main.c
+++ b/main.c
@@ -48,7 +48,7 @@ static ssize_t kxo_state_show(struct device *dev,
                               char *buf)
 {
     read_lock(&attr_obj.lock);
-    int ret = snprintf(buf, 6, "%c %c %c\n", attr_obj.display, attr_obj.resume,
+    int ret = snprintf(buf, 7, "%c %c %c\n", attr_obj.display, attr_obj.resume,
                        attr_obj.end);
     read_unlock(&attr_obj.lock);
     return ret;


### PR DESCRIPTION
When reading `/sys/class/kxo/kxo/kxo_state` using `cat`, the output  lacked a newline, causing the terminal prompt to appear on the same line (e.g., `1 1 0user@Ubuntu:~$`).

The issue was diagnosed by analyzing `kxo_state_show`: the `snprintf` function was called with a size parameter of 6, which includes the null terminator (\0). This left only 5 bytes for the output (e.g., `1 0 0\n`), truncating the newline character (\n). Thus, `kxo_state_show` outputs `1 0 0\0`, not `1 0 0\n\0`.

This patch fixes the issue by increasing the size parameter of `snprintf` from 6 to 7, ensuring the output includes the newline.

[hachmd record](https://hackmd.io/@JeepWay/linux2025-homework3#%E8%AE%80%E5%8F%96-kxo_state-%E6%AA%94%E6%A1%88%E6%B2%92%E6%9C%89%E5%87%BA%E7%8F%BE%E6%8F%9B%E8%A1%8C)