### PR TITLE
Remove redundant memory barrier

### DIFF
--- a/main.c
+++ b/main.c
@@ -292,11 +292,9 @@ static void game_tasklet_func(unsigned long __data)
 
     if (finish && turn == 'O') {
         WRITE_ONCE(finish, 0);
-        smp_wmb();
         queue_work(kxo_workqueue, &ai_one_work);
     } else if (finish && turn == 'X') {
         WRITE_ONCE(finish, 0);
-        smp_wmb();
         queue_work(kxo_workqueue, &ai_two_work);
     }
     queue_work(kxo_workqueue, &drawboard_work);


### PR DESCRIPTION
This pull request removes an extra memory barrier before queuing AI work. As explained in the commit message, the `queue_work()` function provides the necessary memory-ordering guarantees, making the explicit barrier redundant under this project’s usage pattern.

The change was tested by running over 1000 games to verify that turn ordering remains strictly alternating between 'O' and 'X'.
However, this testing is not exhaustive. If you know more rigorous methods to validate memory visibility across CPUs, suggestions are welcome.