### PR TITLE
Resume device output after user program restart

### DIFF
--- a/main.c
+++ b/main.c
@@ -437,6 +437,7 @@ static int kxo_release(struct inode *inode, struct file *filp)
     }
     pr_info("release, current cnt: %d\n", atomic_read(&open_cnt));
     attr_obj.end = 48;
+    attr_obj.display = 49;
 
     return 0;
 }


### PR DESCRIPTION
If the userspace program exits while the game is paused, the `display` flag is not cleared, causing the kernel module to stop producing output. As a result, restarting the program in this state causes it to hang on waiting for device data.

This patch resets the `display` flag on program exit, ensuring the kernel module resumes output normally when the program is restarted.