### PR TITLE
Fix build error on Linux >= 6.12 by guarding no_llseek

### DIFF
--- a/main.c
+++ b/main.c
@@ -457,7 +457,9 @@ static const struct file_operations kxo_fops = {
     .owner = THIS_MODULE,
 #endif
     .read = kxo_read,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
     .llseek = no_llseek,
+#endif
     .open = kxo_open,
     .release = kxo_release,
     .poll = kxo_poll};


### PR DESCRIPTION
Linux 6.12 removed the no_llseek macro. Add a version check so that .llseek = no_llseek is only used on kernels prior to 6.12.