### PR TITLE
Fix high CPU usage when game paused

### DIFF
--- a/user/xo-user.c
+++ b/user/xo-user.c
@@ -99,12 +99,14 @@ static void task_io(int argc, void *argv[])
     int max_fd = *(int *) argv[3];
     struct xo_table xo_tlb;
     fd_set readset;
+    int wait_fd = read_attr ? max_fd : STDIN_FILENO;
 
     FD_ZERO(&readset);
     FD_SET(STDIN_FILENO, &readset);
-    FD_SET(device_fd, &readset);
+    if (read_attr)
+        FD_SET(device_fd, &readset);
 
-    int result = select(max_fd + 1, &readset, NULL, NULL, NULL);
+    int result = select(wait_fd + 1, &readset, NULL, NULL, NULL);
     if (result < 0) {
         printf("Error with select system call\n");
         exit(1);


### PR DESCRIPTION
Stop reading `kxo` device when game is paused.
Only read STDIN for resume game.

Change-Id: I5c44adeed192167998cc71ca3174bc0edc50cdc4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix high CPU use when paused by excluding `/dev/kxo` from `select` and waiting only on `STDIN`.

<sup>Written for commit 00008781863a6716b27dbb5c74f01eb11b2a5444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/kxo/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

